### PR TITLE
chore: can control buildvcs flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ COPY ./go.mod ./
 COPY ./go.sum ./
 RUN go mod download
 COPY ./ ./
-RUN make release
+ARG BUILDVCS=true
+RUN make release BUILDVCS=${BUILDVCS}
 
 #==========================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ COPY ./go.mod ./
 COPY ./go.sum ./
 RUN go mod download
 COPY ./ ./
-ARG BUILDVCS=true
-RUN make release BUILDVCS=${BUILDVCS}
+ARG GOFLAGS
+RUN GOFLAGS="${GOFLAGS}" make release
 
 #==========================
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 VERSION     := $(shell git describe --always --tags --abbrev=10)
 CMDS         = ls -d cmd/* | xargs -I@ basename @
 CONFIG_PKG   = github.com/soranoba/catfish/pkg/config
+BUILDVCS    := $(shell echo $${BUILDVCS:-true})
 
 build:
 	cd cmd/catfish/static && npm ci && npm run build
-	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ ./cmd/@
+	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -buildvcs=${BUILDVCS} -o bin/@ ./cmd/@
 
 release:
 	cd cmd/catfish/static && npm ci && npm run build
 	${CMDS} | CGO_ENABLED=0 GOOS=linux GOARCH=amd64 xargs -I@ \
-		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ -a ./cmd/@
+		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -buildvcs=${BUILDVCS} -o bin/@ -a ./cmd/@
 
 start:
 	cd cmd/catfish/static && npm ci && npm run build

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
 VERSION     := $(shell git describe --always --tags --abbrev=10)
 CMDS         = ls -d cmd/* | xargs -I@ basename @
 CONFIG_PKG   = github.com/soranoba/catfish/pkg/config
-BUILDVCS    := $(shell echo $${BUILDVCS:-true})
 
 build:
 	cd cmd/catfish/static && npm ci && npm run build
-	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -buildvcs=${BUILDVCS} -o bin/@ ./cmd/@
+	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ ./cmd/@
 
 release:
 	cd cmd/catfish/static && npm ci && npm run build
 	${CMDS} | CGO_ENABLED=0 GOOS=linux GOARCH=amd64 xargs -I@ \
-		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -buildvcs=${BUILDVCS} -o bin/@ -a ./cmd/@
+		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ -a ./cmd/@
 
 start:
 	cd cmd/catfish/static && npm ci && npm run build


### PR DESCRIPTION
The build may fail if vcs information is unavailable, such as in CI or if this repo is cloned in git submodule.
This PR makes `buildvcs` flag changeable and leaves the default true.