### PR TITLE
chore: multistage build and confugirable GOARCH

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+./cmd/catfish/static/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make release-js
 
 #==========================
 
-FROM golang:1.19 AS builder
+FROM golang:1.19 AS app-builder
 
 WORKDIR /app
 COPY ./go.mod ./
@@ -27,7 +27,7 @@ RUN GOFLAGS="${GOFLAGS}" GOARCH="${GOARCH}" make release-app
 FROM alpine:latest
 
 WORKDIR /app
-COPY --from=builder /app/bin/catfish /bin/catfish
-COPY --from=builder /app/bin/config.yml /etc/catfish/config.yml
+COPY --from=app-builder /app/bin/catfish /bin/catfish
+COPY --from=app-builder /app/bin/config.yml /etc/catfish/config.yml
 
 ENTRYPOINT ["catfish", "--config", "/etc/catfish/config.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ COPY ./go.mod ./
 COPY ./go.sum ./
 RUN go mod download
 COPY ./ ./
-RUN make release
+ARG BUILDVCS=true
+RUN make release BUILDVCS=${BUILDVCS}
 
 #==========================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 COPY ./cmd/catfish/static/ .
 WORKDIR /app
 COPY ./Makefile ./
-RUN make release-js
+RUN make build-js
 
 #==========================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,27 @@
-FROM golang:1.19 AS builder
+FROM node:16 AS js-builder
 
-RUN apt-get update && \
-    apt-get install -y npm && \
-    apt-get purge -y
+WORKDIR /app/cmd/catfish/static
+COPY ./cmd/catfish/static/package.json .
+COPY ./cmd/catfish/static/package-lock.json .
+RUN npm ci
+COPY ./cmd/catfish/static/ .
+WORKDIR /app
+COPY ./Makefile ./
+RUN make release-js
+
+#==========================
+
+FROM golang:1.19 AS builder
 
 WORKDIR /app
 COPY ./go.mod ./
 COPY ./go.sum ./
 RUN go mod download
 COPY ./ ./
+COPY --from=js-builder /app/cmd/catfish/static/public ./cmd/catfish/static/
 ARG GOFLAGS
-RUN GOFLAGS="${GOFLAGS}" make release
-
+ARG GOARCH=amd64
+RUN GOFLAGS="${GOFLAGS}" GOARCH="${GOARCH}" make release-app
 #==========================
 
 FROM alpine:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ COPY ./go.mod ./
 COPY ./go.sum ./
 RUN go mod download
 COPY ./ ./
-ARG BUILDVCS=true
-RUN make release BUILDVCS=${BUILDVCS}
+ARG GOFLAGS
+RUN GOFLAGS="${GOFLAGS}" make release
 
 #==========================
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ RUN go mod download
 COPY ./ ./
 COPY --from=js-builder /app/cmd/catfish/static/public ./cmd/catfish/static/
 ARG GOFLAGS
+ARG GOOS=linux
 ARG GOARCH=amd64
-RUN GOFLAGS="${GOFLAGS}" GOARCH="${GOARCH}" make release-app
+RUN GOFLAGS="${GOFLAGS}" GOOS="${GOOS}" GOARCH="${GOARCH}" make release-app
 #==========================
 
 FROM alpine:latest

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 VERSION     := $(shell git describe --always --tags --abbrev=10)
 CMDS         = ls -d cmd/* | xargs -I@ basename @
 CONFIG_PKG   = github.com/soranoba/catfish/pkg/config
+BUILDVCS    := $(shell echo $${BUILDVCS:-true})
 
 build:
 	cd cmd/catfish/static && npm ci && npm run build
-	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ ./cmd/@
+	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -buildvcs=${BUILDVCS} -o bin/@ ./cmd/@
 
 release:
 	cd cmd/catfish/static && npm ci && npm run build
 	${CMDS} | CGO_ENABLED=0 GOOS=linux GOARCH=amd64 xargs -I@ \
-		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ -a ./cmd/@
+		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -buildvcs=${BUILDVCS} -o bin/@ -a ./cmd/@
 
 start:
 	cd cmd/catfish/static && npm ci && npm run build

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,15 @@
 VERSION     := $(shell git describe --always --tags --abbrev=10)
 CMDS         = ls -d cmd/* | xargs -I@ basename @
 CONFIG_PKG   = github.com/soranoba/catfish/pkg/config
-BUILDVCS    := $(shell echo $${BUILDVCS:-true})
 
 build:
 	cd cmd/catfish/static && npm ci && npm run build
-	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -buildvcs=${BUILDVCS} -o bin/@ ./cmd/@
+	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ ./cmd/@
 
 release:
 	cd cmd/catfish/static && npm ci && npm run build
 	${CMDS} | CGO_ENABLED=0 GOOS=linux GOARCH=amd64 xargs -I@ \
-		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -buildvcs=${BUILDVCS} -o bin/@ -a ./cmd/@
+		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ -a ./cmd/@
 
 start:
 	cd cmd/catfish/static && npm ci && npm run build

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build-app:
 build-js:
 	cd cmd/catfish/static && npm ci && npm run build
 
-release-app: build-js
+release-app:
 	${CMDS} | xargs -I@ go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ -a ./cmd/@
 
 start:

--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,16 @@ VERSION     := $(shell git describe --always --tags --abbrev=10)
 CMDS         = ls -d cmd/* | xargs -I@ basename @
 CONFIG_PKG   = github.com/soranoba/catfish/pkg/config
 
-build:
-	cd cmd/catfish/static && npm ci && npm run build
+build: build-js build-app
+
+build-app:
 	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ ./cmd/@
 
-release: release-js release-app
-
-release-app:
-	${CMDS} | CGO_ENABLED=0 GOOS=linux xargs -I@ \
-		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ -a ./cmd/@
-
-release-js:
+build-js:
 	cd cmd/catfish/static && npm ci && npm run build
+
+release-app: build-js
+	${CMDS} | xargs -I@ go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ -a ./cmd/@
 
 start:
 	cd cmd/catfish/static && npm ci && npm run build

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,14 @@ build:
 	cd cmd/catfish/static && npm ci && npm run build
 	${CMDS} | xargs -I@ go build -ldflags "-X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ ./cmd/@
 
-release:
-	cd cmd/catfish/static && npm ci && npm run build
-	${CMDS} | CGO_ENABLED=0 GOOS=linux GOARCH=amd64 xargs -I@ \
+release: release-js release-app
+
+release-app:
+	${CMDS} | CGO_ENABLED=0 GOOS=linux xargs -I@ \
 		go build -ldflags "-s -w -X ${CONFIG_PKG}.AppVersion=${VERSION}" -o bin/@ -a ./cmd/@
+
+release-js:
+	cd cmd/catfish/static && npm ci && npm run build
 
 start:
 	cd cmd/catfish/static && npm ci && npm run build


### PR DESCRIPTION
**CAUTION: this PR depends on #1**


## 1. Multistage build for javascript compilation

There is an old version node in golang:1.19 so the below warning was showing
<img width="533" alt="image" src="https://user-images.githubusercontent.com/6465251/194054707-b5e1e0a9-32eb-4617-97f5-1b94694a193a.png">

Changed to use node:16 for javascript compilation

## 2. Make GOARCH settable

`make release` in M1 Mac caused `exec format error` when starting.

Changed Dockerfile to receive a GOARCH build arg.
