### PR TITLE
Include milliseconds in the log output time

### DIFF
--- a/cmd/catfish/log_formatter.go
+++ b/cmd/catfish/log_formatter.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"strings"
-	"time"
 )
 
 type (
@@ -24,7 +23,7 @@ func (f *LogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	jsonEntry := &logEntryJson{
 		Type:    "default",
 		Level:   entry.Level.String(),
-		Time:    entry.Time.Format(time.RFC3339),
+		Time:    entry.Time.Format("2006-01-02T15:04:05.999Z07:00"),
 		Message: entry.Message,
 	}
 


### PR DESCRIPTION
Diff

```diff
{
  "type": "access",
  "level": "info",
-  "time": "2022-11-01T14:12:34+09:00",
+  "time": "2022-11-01T14:12:34.123+09:00",
  "message": "",
  "data": {
    "host": "localhost:8080",
    "method": "GET",
    "status": 500,
    "uri": "/users/1"
  }
}
```
