### PR TITLE
Add functions which name is join, split, add, sub in templates.

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -3,6 +3,7 @@ package template
 import (
 	"bytes"
 	"io"
+	"strings"
 	"text/template"
 )
 
@@ -14,7 +15,12 @@ type (
 )
 
 var (
-	funcmap = template.FuncMap{}
+	funcmap = template.FuncMap{
+		"join":  strings.Join,
+		"split": strings.Split,
+		"add":   add,
+		"sub":   sub,
+	}
 )
 
 func MustCompile(text string) *Template {
@@ -87,4 +93,12 @@ func (t *Template) String() string {
 
 func compile(text string) (*template.Template, error) {
 	return template.New("").Funcs(funcmap).Parse(text)
+}
+
+func add(n1 int, n2 int) int {
+	return n1 + n2
+}
+
+func sub(n1 int, n2 int) int {
+	return n1 - n2
 }

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -35,6 +35,85 @@ func TestTemplate_Render_nil(t *testing.T) {
 	assert.NoError(err)
 }
 
+func TestTemplate_Render_join(t *testing.T) {
+	assert := assert.New(t)
+
+	tpl := MustCompile("{{join . \",\"}}")
+	val, err := tpl.Render([]string{"A", "B", "C"})
+	assert.NoError(err)
+	assert.Equal("A,B,C", val)
+}
+
+func TestTemplate_Render_split(t *testing.T) {
+	assert := assert.New(t)
+
+	tpl := MustCompile("{{split . \",\"}}")
+	val, err := tpl.Render("1,2,3,4,5")
+	assert.NoError(err)
+	assert.Equal("[1 2 3 4 5]", val)
+
+	tpl = MustCompile(`
+{{- $ids := split . "," -}}
+[
+{{- range $idx, $id := $ids}}
+  {
+    "id": {{$id}}
+  }{{if lt $idx (sub (len $ids) 1)}},{{end -}}
+{{end}}
+]`)
+	val, err = tpl.Render("1,2,3,4,5")
+	assert.NoError(err)
+	assert.Equal(`[
+  {
+    "id": 1
+  },
+  {
+    "id": 2
+  },
+  {
+    "id": 3
+  },
+  {
+    "id": 4
+  },
+  {
+    "id": 5
+  }
+]`, val)
+}
+
+func TestTemplate_Render_add(t *testing.T) {
+	assert := assert.New(t)
+
+	tpl := MustCompile("{{add . 3}}")
+	val, err := tpl.Render(2)
+	assert.NoError(err)
+	assert.Equal("5", val)
+
+	val, err = tpl.Render(2.5)
+	assert.Error(err)
+
+	tpl = MustCompile("{{add . 2.5}}")
+	val, err = tpl.Render(2)
+	assert.Error(err)
+}
+
+func TestTemplate_Render_sub(t *testing.T) {
+	assert := assert.New(t)
+
+	tpl := MustCompile("{{sub . 3}}")
+	val, err := tpl.Render(2)
+	assert.NoError(err)
+	assert.Equal("-1", val)
+
+	val, err = tpl.Render(2.5)
+	assert.Error(err)
+
+	tpl = MustCompile("{{sub . 2.5}}")
+	val, err = tpl.Render(2)
+	assert.Error(err)
+}
+
 func TestTemplate_UnmarshalText(t *testing.T) {
 	assert := assert.New(t)
 	tpl := Template{}


### PR DESCRIPTION
Add functions that can be used in the Body template.
See tests for usage.